### PR TITLE
Add device list command

### DIFF
--- a/firmware/src/probe_vendor.c
+++ b/firmware/src/probe_vendor.c
@@ -135,8 +135,9 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
 
   switch (request[0]) {
   case ID_DAP_VENDOR_VERSION:
-    memcpy(response + 2, version_string, sizeof(version_string));
-    rsp_len += sizeof(version_string);
+    // -1: Stripping the trailing nul byte
+    memcpy(response + 2, version_string, sizeof(version_string) - 1);
+    rsp_len += sizeof(version_string) - 1;
     break;
   case ID_DAP_VENDOR_GPIO_SET:
     probe_ioset(request[1], request[2]);

--- a/tool/riotee_probe/cli.py
+++ b/tool/riotee_probe/cli.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import sys
 import click
 from progress.bar import Bar
 from riotee_probe.probe import get_connected_probe
@@ -121,6 +122,19 @@ def get(pin_no):
         state = probe.gpio_get(pin_no)
         click.echo(state)
 
+
+@cli.command
+def list():
+    """Show any connected device and its firmware version"""
+    from . import session
+    printed = False
+    for details in session.get_all():
+        if not printed:
+            print(" ".join("%-20s" % k for k in details.keys()))
+            printed = True
+        print(" ".join("%-20s" % v for v in details.values()))
+    if not printed:
+        print("No probes are currently connected", file=sys.stderr)
 
 if __name__ == "__main__":
     cli()

--- a/tool/riotee_probe/probe.py
+++ b/tool/riotee_probe/probe.py
@@ -54,6 +54,7 @@ class RioteeProbe(object):
 
     def fw_version(self) -> str:
         ret = self._session.vendor_cmd(ReqType.ID_DAP_VENDOR_VERSION)
+        # Firmware versions before 1.0.3 send a trailing nul over the wire
         return str(ret.strip(b'\0'), encoding="utf-8")
 
 

--- a/tool/riotee_probe/probe.py
+++ b/tool/riotee_probe/probe.py
@@ -54,7 +54,7 @@ class RioteeProbe(object):
 
     def fw_version(self) -> str:
         ret = self._session.vendor_cmd(ReqType.ID_DAP_VENDOR_VERSION)
-        return str(ret, encoding="utf-8")
+        return str(ret.strip(b'\0'), encoding="utf-8")
 
 
 class RioteeProbeProbe(RioteeProbe):

--- a/tool/riotee_probe/session.py
+++ b/tool/riotee_probe/session.py
@@ -4,6 +4,29 @@ from pyocd.core.session import Session
 from riotee_probe.protocol import DapRetCode
 from riotee_probe.protocol import ID_DAP_VENDOR0
 
+def get_all():
+    for probe in ConnectHelper.get_all_connected_probes(blocking=False):
+        # Similar steps to RioteeProbeSession, may be deduplicated later.
+        #
+        # (Skipping some that are irrelevant, like the subclass selection or
+        # the product_name propagation -- if refactored, they would probably
+        # resurface)
+        session = RioteeProbeSession()
+        Session.__init__(session, probe, target_override="nrf52")
+        session.open(init_board=False)
+
+        if probe.vendor_name != 'Nessie Circuits':
+            # Getting the firmware version would fail, as would any get/set pin
+            # command -- or worse, it'd do something unexpected.
+            continue
+
+        from .probe import RioteeProbe
+        riotee_probe = RioteeProbe(session)
+        fw = riotee_probe.fw_version()
+
+        yield {"Product name": probe.product_name, "Unique ID": probe.unique_id, "Firmware version": fw}
+
+        session.close()
 
 class RioteeProbeSession(Session):
     def __init__(self):


### PR DESCRIPTION
When getting started with a Riotee board, a common step is to start talking to it without the intention to do anything -- just check it's there.

Reading the firmware version is a good way to do that, but while that was implemented in the tool, it's not exposed.

Apart from fixing bugs around how the firmware version is presented, this introduces a `list` command that enumerates all the available devices, and shows their type, ID and firmware version.

I'd have loved to pull out a filtering argument (to get_all_connected_probes and to choose_probe) out of the two paths into pyOCD, but it seems that there are no filtering arguments apart from the unique ID. Which is sad, because when some other pyOCD compatible board is attached, choose_probe will start asking questions instead of doing the right thing. But that'd be an issue to open there -- for the list feature, culling of non-Nessie boards is done manually.