### PR TITLE
feat/uart tx

### DIFF
--- a/firmware/pico_sdk_import.cmake
+++ b/firmware/pico_sdk_import.cmake
@@ -34,14 +34,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
             )
         endif ()
 

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -133,11 +133,11 @@ int main(void) {
   /* Enables/disables supply of UARTRX level translator */
   gpio_init(PROBE_PIN_TRANS_UARTRX_EN);
   gpio_set_dir(PROBE_PIN_TRANS_UARTRX_EN, GPIO_OUT);
-  gpio_put(PROBE_PIN_TRANS_UARTRX_EN, false);
+  gpio_put(PROBE_PIN_TRANS_UARTRX_EN, true);
 
   gpio_init(PROBE_PIN_TRANS_UARTRX_DIR);
   gpio_set_dir(PROBE_PIN_TRANS_UARTRX_DIR, GPIO_OUT);
-  gpio_put(PROBE_PIN_TRANS_UARTRX_DIR, false);
+  gpio_put(PROBE_PIN_TRANS_UARTRX_DIR, true);
 
   /* Enables/disables supply of UARTTX level translator */
   gpio_init(PROBE_PIN_TRANS_UARTTX_EN);


### PR DESCRIPTION
The UART path from host to target is not working with the current probe/board firmware.
This is implemented 99% of the way, the only bug/oversight/open-issue is enabling the level shifter.

This Pull request enables the level shifter, by driving the control pins accordingly.

Other changes: I had to pin the pico sdk version to the one used back when this was developed (1.5.1). Pico SDK has been bumped to >2.0.0, which does not compile out of the box

If this gets merged, @geissdoerfer  you may want to update the docs, on https://www.riotee.nessie-circuits.de/docs/latest/hardware/probe.html it says "UART data sent from a PC via USB to the Riotee device. Not yet implemented.".
With this patch it is working.

Note: I have not considered implications regarding energy consumption.
I would assume there is no energy leakage across the level shifter and I have not observed changes in battery-free performance of the target. But I also have not done any measurements.