### PR TITLE
feat/enter-pico-bootloader

### DIFF
--- a/firmware/pico_sdk_import.cmake
+++ b/firmware/pico_sdk_import.cmake
@@ -34,14 +34,14 @@ if (NOT PICO_SDK_PATH)
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
                     GIT_SUBMODULES_RECURSE FALSE
             )
         else ()
             FetchContent_Declare(
                     pico_sdk
                     GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG master
+                    GIT_TAG 1.5.1
             )
         endif ()
 

--- a/firmware/src/probe_vendor.c
+++ b/firmware/src/probe_vendor.c
@@ -1,4 +1,5 @@
 
+#include <pico/bootrom.h>
 #include <pico/stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -27,6 +28,7 @@ const char version_string[] = "1.1.0";
 #define ID_DAP_VENDOR_GPIO_SET ID_DAP_Vendor9
 #define ID_DAP_VENDOR_GPIO_GET ID_DAP_Vendor10
 #define ID_DAP_VENDOR_BYPASS ID_DAP_Vendor11
+#define ID_DAP_VENDOR_ENTER_BOOTLOADER ID_DAP_Vendor12
 
 static int power_access_cnt = 0;
 static int prog_access_cnt = 0;
@@ -208,6 +210,9 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
     if (sbw_dev_mem_write(addr, (uint16_t *)&request[6], n_words_w) < 0)
       response[1] = DAP_ERROR;
     gpio_put(PROBE_PIN_LED, !gpio_get(PROBE_PIN_LED));
+    break;
+  case ID_DAP_VENDOR_ENTER_BOOTLOADER:
+    reset_usb_boot(0, 0);
     break;
   default:
     response[0] = ID_DAP_Invalid;


### PR DESCRIPTION
Changing the probe/board firmware requires three hands:
 1. Plugging in the USB cable
 2. Holding the board
 3. Touching the bootloader testpoint to ground

I also screwed the boards down and can no longer touch the testpoint :( 


This is a simple software hack introducing a new DAP vendor command that switches the pico into bootloader mode.
Therefore, no hardware interaction is required to update the board/probe firmware.

This solution is not ideal, it would be even better to use the standard pico USB endpoints, which would provide interoperability with the pico tooling, but integrating this into the current software implementation is a lot of work (messing with endpoints in tinyUSB and stuff). 
For the moment, this works and I think it's fine for most cases.